### PR TITLE
Sending skipped test details for beforeEach, beforeAll and afterEach hooks in mocha (v7)

### DIFF
--- a/packages/wdio-browserstack-service/src/insights-handler.ts
+++ b/packages/wdio-browserstack-service/src/insights-handler.ts
@@ -103,7 +103,7 @@ export default class InsightsHandler {
                     }
                 }
 
-                await sendSuiteSkipped(test.ctx.currentTest.parent)
+                await sendSuiteSkipped(test.ctx.test.parent)
             }
         }
     }

--- a/packages/wdio-browserstack-service/src/insights-handler.ts
+++ b/packages/wdio-browserstack-service/src/insights-handler.ts
@@ -69,6 +69,42 @@ export default class InsightsHandler {
                 }
             }
             await this.sendTestRunEvent(test, 'HookRunFinished', result)
+
+            const hookType = getHookType(test.title)
+            /*
+                If any of the `beforeAll`, `beforeEach`, `afterEach` then the tests after the hook won't run in mocha (https://github.com/mochajs/mocha/issues/4392)
+                So if any of this hook fails, then we are sending the next tests in the suite as skipped.
+                This won't be needed for `afterAll`, as even if `afterAll` fails all the tests that we need are already run by then, so we don't need to send the stats for them separately
+             */
+            if (!result.passed && (hookType === 'BEFORE_EACH' || hookType === 'BEFORE_ALL' || hookType === 'AFTER_EACH')) {
+                const sendTestSkip = async (skippedTest: any) => {
+
+                    // We only need to send the tests that whose state is not determined yet. The state of tests which is determined will already be sent.
+                    if (skippedTest.state === undefined) {
+                        const fullTitle = `${skippedTest.parent.title} - ${skippedTest.title}`
+                        this._tests[fullTitle] = {
+                            uuid: uuidv4(),
+                            startedAt: (new Date()).toISOString(),
+                            finishedAt: (new Date()).toISOString()
+                        }
+                        await this.sendTestRunEvent(skippedTest, 'TestRunSkipped')
+                    }
+                }
+
+                /*
+                    Recursively send the tests as skipped for all suites below the hook. This is to handle nested describe blocks
+                 */
+                const sendSuiteSkipped = async (suite: any) => {
+                    for (const skippedTest of suite.tests) {
+                        await sendTestSkip(skippedTest)
+                    }
+                    for (const skippedSuite of suite.suites) {
+                        await sendSuiteSkipped(skippedSuite)
+                    }
+                }
+
+                await sendSuiteSkipped(test.ctx.currentTest.parent)
+            }
         }
     }
 
@@ -280,7 +316,8 @@ export default class InsightsHandler {
     private getHierarchy (test: Frameworks.Test) {
         const value: string[] = []
         if (test.ctx && test.ctx.test) {
-            let parent = test.ctx.test.parent
+            // If we already have the parent object, utilize it else get from context
+            let parent = typeof test.parent === 'object' ? test.parent : test.ctx.test.parent
             while (parent && parent.title !== '') {
                 value.push(parent.title)
                 parent = parent.parent
@@ -333,12 +370,17 @@ export default class InsightsHandler {
             }
         }
 
-        if (eventType == 'TestRunStarted') {
+        if (eventType === 'TestRunStarted' || eventType === 'TestRunSkipped') {
             testData.integrations = {}
             if (this._browser && this._platformMeta) {
                 const provider = getCloudProvider(this._browser)
                 testData.integrations[provider] = this.getIntegrationsObject()
             }
+        }
+
+        if (eventType === 'TestRunSkipped') {
+            testData.result = 'skipped'
+            eventType = 'TestRunFinished'
         }
 
         const uploadData: UploadType = {

--- a/packages/wdio-browserstack-service/src/util.ts
+++ b/packages/wdio-browserstack-service/src/util.ts
@@ -319,7 +319,13 @@ export async function getGitMetaData () {
 }
 
 export function getUniqueIdentifier(test: Frameworks.Test): string {
-    return `${test.parent} - ${test.title}`
+    let parentTitle = test.parent
+    // Sometimes parent will be an object instead of a string
+    if (typeof test.parent === 'object') {
+        // @ts-ignore
+        parentTitle = parentTitle.title
+    }
+    return `${parentTitle} - ${test.title}`
 }
 
 export function getUniqueIdentifierForCucumber(world: ITestCaseHookParameter): string {
@@ -437,13 +443,13 @@ export function getHierarchy(fullTitle?: string) {
 }
 
 export function getHookType (hookName: string): string {
-    if (hookName.includes('before each')) {
+    if (hookName.includes('"before each"')) {
         return 'BEFORE_EACH'
-    } else if (hookName.includes('before all')) {
+    } else if (hookName.includes('"before all"')) {
         return 'BEFORE_ALL'
-    } else if (hookName.includes('after each')) {
+    } else if (hookName.includes('"after each"')) {
         return 'AFTER_EACH'
-    } else if (hookName.includes('after all')) {
+    } else if (hookName.includes('"after all"')) {
         return 'AFTER_ALL'
     }
     return 'unknown'

--- a/packages/wdio-browserstack-service/tests/insight-handler.test.ts
+++ b/packages/wdio-browserstack-service/tests/insight-handler.test.ts
@@ -537,14 +537,14 @@ describe('afterHook', () => {
 
         it('add hook data', async () => {
             insightsHandler['_tests'] = {}
-            await insightsHandler.afterHook({ parent: 'parent', title: 'test' } as any, {} as any, {} as any)
+            await insightsHandler.afterHook({ parent: 'parent', title: 'test' } as any, { passed: true } as any)
             expect(insightsHandler['_tests']).toEqual({ 'test title': { finishedAt: '2020-01-01T00:00:00.000Z', } })
             expect(sendSpy).toBeCalledTimes(1)
         })
 
         it('update hook data', async () => {
             insightsHandler['_tests'] = { 'test title': {} }
-            await insightsHandler.afterHook({ parent: 'parent', title: 'test' } as any, {} as any, {} as any)
+            await insightsHandler.afterHook({ parent: 'parent', title: 'test' } as any, { passed: true } as any)
             expect(insightsHandler['_tests']).toEqual({ 'test title': { finishedAt: '2020-01-01T00:00:00.000Z', } })
             expect(sendSpy).toBeCalledTimes(1)
         })

--- a/packages/wdio-browserstack-service/tests/util.test.ts
+++ b/packages/wdio-browserstack-service/tests/util.test.ts
@@ -725,10 +725,10 @@ describe('getGitMetaData', () => {
 
 describe('getHookType', () => {
     it('get hook type as string', () => {
-        expect(getHookType('before each hook for test 1')).toEqual('BEFORE_EACH')
-        expect(getHookType('after each hook for test 1')).toEqual('AFTER_EACH')
-        expect(getHookType('before all hook for test 1')).toEqual('BEFORE_ALL')
-        expect(getHookType('after all hook for test 1')).toEqual('AFTER_ALL')
+        expect(getHookType('"before each" hook for test 1')).toEqual('BEFORE_EACH')
+        expect(getHookType('"after each" hook for test 1')).toEqual('AFTER_EACH')
+        expect(getHookType('"before all" hook for test 1')).toEqual('BEFORE_ALL')
+        expect(getHookType('"after all" hook for test 1')).toEqual('AFTER_ALL')
         expect(getHookType('no hook test')).toEqual('unknown')
     })
 })


### PR DESCRIPTION
## Proposed changes
- Sending test details as skipped whenever hook fails along with hook failure details

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
